### PR TITLE
CSHARP-1501: Drivers must raise an error if response messageLength > ismaster.maxMessageSizeBytes

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -126,14 +126,6 @@ namespace MongoDB.Driver.Core.Connections
             get { return _endPoint; }
         }
 
-        private void EnsureMessageSizeIsValid(Int32 messageSize)
-        {
-            if (messageSize < 0 || messageSize > _description.MaxMessageSize)
-            {
-                throw new FormatException("The size of the message is invalid.");
-            }
-        }
-
         public bool IsExpired
         {
             get

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -318,6 +318,7 @@ namespace MongoDB.Driver.Core.Connections
         {
             if (messageSize < 0 || messageSize > _description.MaxMessageSize)
             {
+                // What kind of exception to use here?
                 throw new MongoInternalException("The size of the message is invalid.");
             }
         }
@@ -326,7 +327,6 @@ namespace MongoDB.Driver.Core.Connections
             try
             {
                 var messageSizeBytes = new byte[4];
-                messageSizeBytes[0] = (Byte)(_description.MaxMessageSize);
                 _stream.ReadBytes(messageSizeBytes, 0, 4, _backgroundTaskCancellationToken);
                 var messageSize = BitConverter.ToInt32(messageSizeBytes, 0);
                 EnsureMessageSizeIsValid(messageSize);

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -226,7 +226,7 @@ namespace MongoDB.Driver.Core.Connections
 
             if (messageSize < 0 || messageSize > maxMessageSize)
             {
-                    throw new FormatException("The size of the message is invalid.");
+                throw new FormatException("The size of the message is invalid.");
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -220,11 +220,13 @@ namespace MongoDB.Driver.Core.Connections
             }
         }
 
-        private void EnsureMessageSizeIsValid(Int32 messageSize)
+        private void EnsureMessageSizeIsValid(int messageSize)
         {
-            if (messageSize < 0 || messageSize > _description.MaxMessageSize)
+            var maxMessageSize = _description?.MaxMessageSize ?? 48000000;
+
+            if (messageSize < 0 || messageSize > maxMessageSize)
             {
-                throw new FormatException("The size of the message is invalid.");
+                    throw new FormatException("The size of the message is invalid.");
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -126,6 +126,14 @@ namespace MongoDB.Driver.Core.Connections
             get { return _endPoint; }
         }
 
+        private void EnsureMessageSizeIsValid(Int32 messageSize)
+        {
+            if (messageSize < 0 || messageSize > _description.MaxMessageSize)
+            {
+                throw new FormatException("The size of the message is invalid.");
+            }
+        }
+
         public bool IsExpired
         {
             get
@@ -217,6 +225,14 @@ namespace MongoDB.Driver.Core.Connections
                         _closedEventHandler(new ConnectionClosedEvent(_connectionId, stopwatch.Elapsed, EventContext.OperationId));
                     }
                 }
+            }
+        }
+
+        private void EnsureMessageSizeIsValid(Int32 messageSize)
+        {
+            if (messageSize < 0 || messageSize > _description.MaxMessageSize)
+            {
+                throw new FormatException("The size of the message is invalid.");
             }
         }
 
@@ -314,14 +330,6 @@ namespace MongoDB.Driver.Core.Connections
             }
         }
 
-        private void EnsureMessageSizeIsValid(Int32 messageSize)
-        {
-            if (messageSize < 0 || messageSize > _description.MaxMessageSize)
-            {
-                // What kind of exception to use here?
-                throw new MongoInternalException("The size of the message is invalid.");
-            }
-        }
         private IByteBuffer ReceiveBuffer()
         {
             try

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -235,9 +235,9 @@ namespace MongoDB.Driver.Core.Connections
                         .ReturnsAsync(stream);
                     _subject.OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
                     exception = Record
-                        .ExceptionAsync(async () => await _subject.ReceiveMessageAsync(10, encoderSelector, _messageEncoderSettings, CancellationToken.None))
+                        .Exception(() => _subject.ReceiveMessageAsync(10, encoderSelector, _messageEncoderSettings, CancellationToken.None)
                         .GetAwaiter()
-                        .GetResult();
+                        .GetResult());
                 }
                 else
                 {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -236,7 +236,8 @@ namespace MongoDB.Driver.Core.Connections
                     _subject.OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
                     exception = Record
                         .ExceptionAsync(async () => await _subject.ReceiveMessageAsync(10, encoderSelector, _messageEncoderSettings, CancellationToken.None))
-                        .GetAwaiter().GetResult();
+                        .GetAwaiter()
+                        .GetResult();
                 }
                 else
                 {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -310,8 +310,9 @@ namespace MongoDB.Driver.Core.Connections
                     invalidSizeException = Record.Exception( () =>  _subject.ReceiveMessage(10, encoderSelector, _messageEncoderSettings, CancellationToken.None));
                 }
 
-                Assert.NotNull(invalidSizeException);
-                Assert.IsType<MongoInternalException>(invalidSizeException.InnerException);
+                invalidSizeException.Should().NotBe(null);
+                invalidSizeException.InnerException.Should().BeOfType<MongoInternalException>();
+                invalidSizeException.InnerException.Message.Should().Be("The size of the message is invalid.");
             }
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -53,18 +53,18 @@ namespace MongoDB.Driver.Core.Connections
 
             _endPoint = new DnsEndPoint("localhost", 27017);
             var serverId = new ServerId(new ClusterId(), _endPoint);
+            var connectionId = new ConnectionId(serverId);
+            var isMasterResult = new IsMasterResult(new BsonDocument { { "ok", 1 }, { "maxMessageSizeBytes", 48000000 } });
+            var buildInfoResult = new BuildInfoResult(new BsonDocument { { "ok", 1 }, { "version", "2.6.3" } });
+            var connectionDescription = new ConnectionDescription(connectionId, isMasterResult, buildInfoResult);
 
             _mockConnectionInitializer = new Mock<IConnectionInitializer>();
-            _mockConnectionInitializer.Setup(i => i.InitializeConnection(It.IsAny<IConnection>(), CancellationToken.None))
-                .Returns(() => new ConnectionDescription(
-                    new ConnectionId(serverId),
-                    new IsMasterResult(new BsonDocument()),
-                    new BuildInfoResult(new BsonDocument("version", "2.6.3"))));
-            _mockConnectionInitializer.Setup(i => i.InitializeConnectionAsync(It.IsAny<IConnection>(), CancellationToken.None))
-                .Returns(() => Task.FromResult(new ConnectionDescription(
-                    new ConnectionId(serverId),
-                    new IsMasterResult(new BsonDocument()),
-                    new BuildInfoResult(new BsonDocument("version", "2.6.3")))));
+            _mockConnectionInitializer
+                .Setup(i => i.InitializeConnection(It.IsAny<IConnection>(), CancellationToken.None))
+                .Returns(connectionDescription);
+            _mockConnectionInitializer
+                .Setup(i => i.InitializeConnectionAsync(It.IsAny<IConnection>(), CancellationToken.None))
+                .Returns(Task.FromResult(connectionDescription));
 
             _subject = new BinaryConnection(
                 serverId: serverId,
@@ -214,6 +214,46 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
+        public void ReceiveMessage_should_throw_a_FormatException_when_message_is_an_invalid_size(
+            [Values(-1, 48000001)]
+            int length,
+            [Values(false, true)]
+            bool async)
+        {
+            using (var stream = new BlockingMemoryStream())
+            {
+                var bytes = BitConverter.GetBytes(length);
+                stream.Write(bytes, 0, bytes.Length);
+                stream.Seek(0, SeekOrigin.Begin);
+                var encoderSelector = new ReplyMessageEncoderSelector<BsonDocument>(BsonDocumentSerializer.Instance);
+
+                Exception exception;
+                if (async)
+                {
+                    _mockStreamFactory.Setup(f => f.CreateStreamAsync(_endPoint, CancellationToken.None))
+                        .Returns(Task.FromResult<Stream>(stream));
+                    _subject.OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    exception = Record.Exception(() => _subject
+                        .ReceiveMessageAsync(10, encoderSelector, _messageEncoderSettings, CancellationToken.None)
+                        .GetAwaiter().GetResult());
+                }
+                else
+                {
+                    _mockStreamFactory.Setup(f => f.CreateStream(_endPoint, CancellationToken.None))
+                        .Returns(stream);
+                    _subject.Open(CancellationToken.None);
+
+                    exception = Record.Exception( () =>  _subject.ReceiveMessage(10, encoderSelector, _messageEncoderSettings, CancellationToken.None));
+                }
+
+                exception.Should().BeOfType<MongoConnectionException>();
+                exception.InnerException.Should().BeOfType<FormatException>();
+                exception.InnerException.Message.Should().Be("The size of the message is invalid.");
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData]
         public void ReceiveMessage_should_throw_an_ArgumentNullException_when_the_encoderSelector_is_null(
             [Values(false, true)]
             bool async)
@@ -274,46 +314,6 @@ namespace MongoDB.Driver.Core.Connections
             }
 
             act.ShouldThrow<InvalidOperationException>();
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        public void ReceiveMessage_should_throw_error_when_message_is_an_invalid_size(
-            [Values(-1, 16000005)]
-            int length,
-            [Values(false, true)]
-            bool async)
-        {
-            using (var stream = new BlockingMemoryStream())
-            {
-                var bytes = BitConverter.GetBytes(length);
-                stream.Write(bytes, 0, bytes.Length);
-                stream.Seek(0, SeekOrigin.Begin);
-                var encoderSelector = new ReplyMessageEncoderSelector<BsonDocument>(BsonDocumentSerializer.Instance);
-
-                Exception invalidSizeException;
-                if (async)
-                {
-                    _mockStreamFactory.Setup(f => f.CreateStreamAsync(_endPoint, CancellationToken.None))
-                        .Returns(Task.FromResult<Stream>(stream));
-                    _subject.OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
-                    invalidSizeException = Record.Exception(() => _subject
-                        .ReceiveMessageAsync(10, encoderSelector, _messageEncoderSettings, CancellationToken.None)
-                        .GetAwaiter().GetResult());
-                }
-                else
-                {
-                    _mockStreamFactory.Setup(f => f.CreateStream(_endPoint, CancellationToken.None))
-                        .Returns(stream);
-                    _subject.Open(CancellationToken.None);
-
-                    invalidSizeException = Record.Exception( () =>  _subject.ReceiveMessage(10, encoderSelector, _messageEncoderSettings, CancellationToken.None));
-                }
-
-                invalidSizeException.Should().NotBe(null);
-                invalidSizeException.InnerException.Should().BeOfType<MongoInternalException>();
-                invalidSizeException.InnerException.Message.Should().Be("The size of the message is invalid.");
-            }
         }
 
         [Theory]


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-1501
~~https://evergreen.mongodb.com/version/5d0d464232f41749162d93a7~~
~~https://evergreen.mongodb.com/version/5d10da1e9ccd4e148cd09c92~~

Ready for interim review.